### PR TITLE
Prevent sending notifications when OK

### DIFF
--- a/src/Health/Checks/EnvVars.php
+++ b/src/Health/Checks/EnvVars.php
@@ -55,8 +55,7 @@ class EnvVars extends Check
         }
 
         return $result->ok()
-            ->shortSummary(trans('health-env-vars::translations.every_var_has_been_set'))
-            ->notificationMessage(trans('health-env-vars::translations.every_var_has_been_set'));
+            ->shortSummary(trans('health-env-vars::translations.every_var_has_been_set'));
     }
 
     /**


### PR DESCRIPTION
When Check has notification it's considered as a Failed and notification is sent (as a description of the Fail: https://github.com/spatie/laravel-health/blob/main/src/Commands/RunHealthChecksCommand.php#L97), but check is OK.. :)
So, I just receives every hour email with:

Laravel Health
The following checks reported warnings and errors:

- Env Vars: Every required .env variable has been set

Hope, it will help.